### PR TITLE
fix broken link

### DIFF
--- a/cloudsdk/README.md
+++ b/cloudsdk/README.md
@@ -8,4 +8,4 @@ This repository contains a tutorial to help you make the most of gcloud command 
 Launch the tutorial with Cloud Shell:
 
 [![Open this tutorial in Cloud
-Shell](http://gstatic.com/cloudssh/images/open-btn.png)](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/GoogleCloudPlatform/cloud-shell-tutorials/cloudsdk/filter-format-tutorial.git&page=editor&tutorial=tutorial.md)
+Shell](http://gstatic.com/cloudssh/images/open-btn.png)](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/GoogleCloudPlatform/cloud-shell-tutorials.git&page=editor&working_dir=cloudsdk&tutorial=tutorial.md)


### PR DESCRIPTION
The Open in Cloud Shell link for the tutorial nested in the cloudsdk directory was not working.  The fix was to adjust parameters to refer to correct .git repo url while specifying an additional working_dir parameter.