### PR TITLE
Make non-command text easier to read.

### DIFF
--- a/tutorial.md
+++ b/tutorial.md
@@ -64,15 +64,19 @@ To write your tutorial, use [Markdown](https://en.wikipedia.org/wiki/Markdown) a
 
 Modify the title of this tutorial ('# Introduction to writing tutorials in Cloud Shell') by changing it to:
 
-    # Teach me to write a tutorial
-
+```
+# Teach me to write a tutorial
+```
 
 ### Add a new step
 
 Next, add a step just after the title like this:
 
-    ## Step 1
-    This is a new step I’ve just added.
+```
+## Step 1
+This is a new step I’ve just added.
+```
+
 Each 'step' of a tutorial is displayed on one page. To move through steps, users use the 'Back' and 'Next' buttons.
 
 
@@ -80,7 +84,9 @@ Each 'step' of a tutorial is displayed on one page. To move through steps, users
 
 To list items that are part of a tutorial step under a particular step heading, add them as such:
 
-    ### This is an item under your first step
+```
+### This is an item under your first step
+```
 
 The tutorial engine also supports Markdown features like links and images. Note, **including HTML is not supported**.
 
@@ -105,10 +111,12 @@ In the Markdown for your tutorial, you may include special directives that are s
 ### Trigger file actions in the text editor
 To include a link to <walkthrough-editor-open-file filePath="cloud-shell-tutorials/tutorial.md">open a file for editing</walkthrough-editor-open-file>, use:
 
-    <walkthrough-editor-open-file
-        filePath="cloud-shell-tutorials/tutorial.md">
-      open a file for editing
-    </walkthrough-editor-open-file>
+```
+<walkthrough-editor-open-file
+    filePath="cloud-shell-tutorials/tutorial.md">
+    open a file for editing
+</walkthrough-editor-open-file>
+```
 
 
 ### Highlight a UI element
@@ -119,15 +127,19 @@ You may want to show people where to find the web preview icon to view the web s
 
 Display the web preview icon <walkthrough-web-preview-icon></walkthrough-web-preview-icon> by including this in your tutorial’s Markdown:
 
-    <walkthrough-web-preview-icon>
-    </walkthrough-web-preview-icon>
+```
+<walkthrough-web-preview-icon>
+</walkthrough-web-preview-icon>
+```
 
 To create a link that shines a <walkthrough-spotlight-pointer spotlightId="devshell-web-preview-button">spotlight on the web preview icon</walkthrough-spotlight-pointer>, add the following:
 
-    <walkthrough-spotlight-pointer
-        spotlightId="devshell-web-preview-button">
-      spotlight on the web preview icon
-    </walkthrough-spotlight-pointer>
+```
+<walkthrough-spotlight-pointer
+    spotlightId="devshell-web-preview-button">
+    spotlight on the web preview icon
+</walkthrough-spotlight-pointer>
+```
 
 You can find a list of supported spotlight targets in the [documentation for Cloud Shell Tutorials](https://cloud.google.com/shell/docs/tutorials).
 
@@ -149,9 +161,11 @@ To build a link for the 'Open in Cloud Shell' feature, start with this base HTML
 
 **`TUTORIAL_FILE.md`** with your tutorial’s Markdown file. The path to the file is relative to the root directory of your project repository.
 
-    <a  href="https://console.cloud.google.com/cloudshell/open?git_repo=YOUR_REPO_URL_HERE&tutorial=TUTORIAL_FILE.md">
-      <img alt="Open in Cloud Shell" src="http://gstatic.com/cloudssh/images/open-btn.png">
-    </a>
+```
+<a  href="https://console.cloud.google.com/cloudshell/open?git_repo=YOUR_REPO_URL_HERE&tutorial=TUTORIAL_FILE.md">
+    <img alt="Open in Cloud Shell" src="http://gstatic.com/cloudssh/images/open-btn.png">
+</a>
+```
 
 Once you've edited the above HTML with the appropriate values for `git_repo` and `tutorial`, use the HTML snippet to generate the 'Open in Cloud Shell' button for your project.
 
@@ -160,7 +174,9 @@ Once you've edited the above HTML with the appropriate values for `git_repo` and
 
 If you are posting the 'Open in Cloud Shell' button in a location that accepts Markdown instead of HTML, use this example instead:
 
-    [![Open this project in Cloud Shell](http://gstatic.com/cloudssh/images/open-btn.png)](https://console.cloud.google.com/cloudshell/open?git_repo=YOUR_REPO_URL_HERE&page=editor&tutorial=TUTORIAL_FILE.md)
+```
+[![Open this project in Cloud Shell](http://gstatic.com/cloudssh/images/open-btn.png)](https://console.cloud.google.com/cloudshell/open?git_repo=YOUR_REPO_URL_HERE&page=editor&tutorial=TUTORIAL_FILE.md)
+```
 
 Likewise, once you've replaced `YOUR_REPO_URL_HERE` and `TUTORIAL_FILE.md` in the 'Open in Cloud Shell' URL as described above, the resulting Markdown snippet can be used to create your button.
 


### PR DESCRIPTION
Surrounds commands in triple backticks, making it code pretty, but not like it's a shell command. Sample:

![w9rnj8r0ve9](https://user-images.githubusercontent.com/13141550/52232921-c9a35300-288b-11e9-806f-c4256d22e8d0.png)
