### PR TITLE
Correct button name in tutorial

### DIFF
--- a/tutorial.md
+++ b/tutorial.md
@@ -9,7 +9,7 @@ This guide will show you how to build your own interactive tutorial (like this o
 
 **Time to complete**: About 10 minutes
 
-Click the **Next** button to move to the next step.
+Click the **Start** button to move to the next step.
 
 
 ## What is Cloud Shell?


### PR DESCRIPTION
The first part of a tutorial, the button will be named *Start* and not
*Next*. However, before this CL, the tutorial.md suggests the user
click *Next*.